### PR TITLE
Add basic gate and tower mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
     <div id="ui">
         <button id="startBtn">Start Wave</button>
         <button id="buildWallBtn">Build Wall</button>
+        <button id="buildGateBtn">Build Gate</button>
+        <button id="buildTowerBtn">Build Tower</button>
+        <button id="openGateBtn">Open Gates</button>
+        <button id="closeGateBtn">Close Gates</button>
         <span id="waveCounter">Wave: 0</span>
         <span id="castleHp">Castle HP: 100</span>
         <span id="stone">Stone: 100</span>

--- a/map.js
+++ b/map.js
@@ -1,7 +1,7 @@
 const MAP_SIZE = 64; // 64x64 grid
 const TILE_SIZE = 10; // pixels
-const BUILD_ZONE_START = 22; // 20x20 center area -> start index 22 to 42 for 64 grid
-const BUILD_ZONE_END = 42;
+let buildZoneStart = 22; // 20x20 center area -> start index 22 to 42 for 64 grid
+let buildZoneEnd = 42;
 
 export function drawGrid(ctx) {
     ctx.strokeStyle = '#333';
@@ -21,9 +21,20 @@ export function drawGrid(ctx) {
 
 export function inBuildZone(x, y) {
     return (
-        x >= BUILD_ZONE_START &&
-        x < BUILD_ZONE_END &&
-        y >= BUILD_ZONE_START &&
-        y < BUILD_ZONE_END
+        x >= buildZoneStart &&
+        x < buildZoneEnd &&
+        y >= buildZoneStart &&
+        y < buildZoneEnd
     );
+}
+
+export function expandBuildZone() {
+    if (buildZoneStart > 12) {
+        buildZoneStart -= 5;
+        buildZoneEnd += 5;
+    }
+}
+
+export function getBuildZone() {
+    return { start: buildZoneStart, end: buildZoneEnd };
 }

--- a/ui.js
+++ b/ui.js
@@ -1,9 +1,18 @@
-export function setupUI(onStartWave, onToggleBuild) {
+export function setupUI(onStartWave, onBuildWall, onBuildGate, onBuildTower, onOpenGate, onCloseGate) {
     const btn = document.getElementById('startBtn');
     btn.addEventListener('click', onStartWave);
 
     const buildBtn = document.getElementById('buildWallBtn');
-    buildBtn.addEventListener('click', onToggleBuild);
+    buildBtn.addEventListener('click', onBuildWall);
+
+    const gateBtn = document.getElementById('buildGateBtn');
+    gateBtn.addEventListener('click', onBuildGate);
+
+    const towerBtn = document.getElementById('buildTowerBtn');
+    towerBtn.addEventListener('click', onBuildTower);
+
+    document.getElementById('openGateBtn').addEventListener('click', onOpenGate);
+    document.getElementById('closeGateBtn').addEventListener('click', onCloseGate);
 }
 
 export function updateWave(wave) {


### PR DESCRIPTION
## Summary
- expand build zone dynamically
- implement gate structures with open/close cooldown
- add simple tower attacks with bullets
- update enemy AI to pathfind around closed gates and walls
- extend UI with buttons for building gates/towers and gate controls

## Testing
- `node --check main.js`
- `node --check ai.js`
- `node --check map.js`
- `node --check ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68705d8ba36c8332baf2547ab7ff66ec