### PR TITLE
Fix wave summary popup and improve responsive UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,19 +8,27 @@
 </head>
 <body>
     <div id="ui">
-        <button id="startBtn">Start Wave</button>
-        <button id="buildWallBtn">Build Wall</button>
-        <button id="buildGateBtn">Build Gate</button>
-        <button id="buildTowerBtn">Build Tower</button>
-        <button id="deleteBtn">Delete</button>
-        <button id="openGateBtn">Open Gates</button>
-        <button id="closeGateBtn">Close Gates</button>
-        <span id="waveCounter">Wave: 0</span>
-        <span id="castleHp">Castle HP: 100</span>
-        <span id="stone">Stone: 100</span>
-        <span id="wood">Wood: 150</span>
-        <span id="gold">Gold: 200</span>
-        <span id="essence">Essence: 0</span>
+        <div id="controls">
+            <button id="startBtn">Start Wave</button>
+            <div class="group">
+                <button id="buildWallBtn">Build Wall</button>
+                <button id="buildGateBtn">Build Gate</button>
+                <button id="buildTowerBtn">Build Tower</button>
+                <button id="deleteBtn">Delete</button>
+            </div>
+            <div class="group">
+                <button id="openGateBtn">Open Gates</button>
+                <button id="closeGateBtn">Close Gates</button>
+            </div>
+        </div>
+        <div id="resources">
+            <span id="waveCounter">Wave: 0</span>
+            <span id="castleHp">Castle HP: 100</span>
+            <span id="stone">Stone: 100</span>
+            <span id="wood">Wood: 150</span>
+            <span id="gold">Gold: 200</span>
+            <span id="essence">Essence: 0</span>
+        </div>
     </div>
     <canvas id="gameCanvas" width="640" height="640"></canvas>
 

--- a/main.js
+++ b/main.js
@@ -123,7 +123,7 @@ function gameLoop() {
         towers.forEach(t => { if (t.cooldown > 0) t.cooldown -= 1; });
 
         ai.draw(ctx, TILE_SIZE);
-        if (ai.enemies.length === 0) {
+        if (running && ai.enemies.length === 0) {
             endWave();
         }
 

--- a/style.css
+++ b/style.css
@@ -13,17 +13,48 @@ body {
 }
 
 #ui {
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
     margin: 10px;
 }
 
+#controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+}
+
+#controls .group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+}
+
+#resources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+}
+
 span {
-    margin-right: 10px;
+    margin-right: 5px;
 }
 
 button {
-    padding: 5px 10px;
-    margin-right: 10px;
+    padding: 8px 12px;
+    margin: 5px;
+}
+
+@media (min-width: 600px) {
+    #controls {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- avoid calling `endWave()` before any wave is started
- group action buttons and resource display in the UI
- implement responsive flexbox layout for better desktop/mobile experience

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687241e91b7083329b095d026dfaf4c7