### PR TITLE
Improve mobile UI and combat

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -7,6 +7,8 @@ class Enemy {
         this.alive = true;
         this.hp = type === 'elite' ? 30 : 10;
         this.score = 0;
+        this.attackCooldown = 0;
+        this.atCastle = false;
     }
 
     takeDamage(dmg) {
@@ -20,6 +22,16 @@ class Enemy {
     update(castle, walls, gates, rocks, water) {
         if (!this.alive) return;
         this.score += 1 / 60;
+        if (this.atCastle) {
+            if (this.attackCooldown <= 0) {
+                castle.hp -= 1;
+                this.attackCooldown = 60;
+            } else {
+                this.attackCooldown -= 1;
+            }
+            return;
+        }
+
         const startX = Math.floor(this.x);
         const startY = Math.floor(this.y);
         const next = findNextStep(startX, startY, castle, walls, gates, rocks);
@@ -29,18 +41,13 @@ class Enemy {
         const dx = tx - this.x;
         const dy = ty - this.y;
         const dist = Math.hypot(dx, dy);
-            if (dist < 0.01) {
-                // reached center of cell
-                if (next.x === castle.x && next.y === castle.y) {
-                castle.hp -= 1;
-                this.score += 300;
-                this.alive = false;
-                return;
-                }
-            }
+        if (dist < 0.01 && next.x === castle.x && next.y === castle.y) {
+            this.atCastle = true;
+            return;
+        }
         if (dist > 0) {
             let speed = this.speed;
-            if(water && water.some(w=>w.x===Math.floor(this.x)&&w.y===Math.floor(this.y))) speed *= 0.5;
+            if (water && water.some(w => w.x === Math.floor(this.x) && w.y === Math.floor(this.y))) speed *= 0.5;
             const step = Math.min(speed, dist);
             this.x += (dx / dist) * step;
             this.y += (dy / dist) * step;

--- a/base.css
+++ b/base.css
@@ -51,6 +51,17 @@ button {
     cursor: pointer;
 }
 
+.start-fab {
+    background: #a00;
+    color: #fff;
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+}
+
 @media (min-width: 600px) {
     #controls {
         flex-direction: row;

--- a/index.html
+++ b/index.html
@@ -23,19 +23,27 @@
     <main id="gameArea">
         <canvas id="gameCanvas" width="640" height="640" tabindex="0"></canvas>
         <button id="analyticsBtn" class="fab" aria-label="Analytics">&#128202;</button>
+        <button id="startBtn" class="fab start-fab" aria-label="Start Wave">Start</button>
     </main>
-    <div id="bottomSheet" class="sheet">
+    <div id="bottomSheet" class="sheet is-open">
         <button class="sheet-handle" id="sheetToggle">^</button>
-        <div class="icon-row">
+        <div class="icon-row group">
             <button id="buildWallBtn" aria-label="Build Wall">&#128679;</button>
             <button id="buildGateBtn" aria-label="Build Gate">&#128682;</button>
+        </div>
+        <div class="icon-row group">
             <button id="buildTowerBtn" aria-label="Build Tower">&#127993;</button>
+        </div>
+        <div class="icon-row group">
+            <button id="spawnSquadBtn" aria-label="Spawn Squad">&#9876;</button>
+        </div>
+        <div class="icon-row group">
             <button id="deleteBtn" aria-label="Delete">&#9881;&#65039;</button>
         </div>
         <div class="group">
-            <button id="startBtn" aria-label="Start Wave">Start</button>
             <button id="openGateBtn" aria-label="Open Gates">Open</button>
             <button id="closeGateBtn" aria-label="Close Gates">Close</button>
+            <button id="techBtn" aria-label="Tech Tree">Tech</button>
         </div>
     </div>
     <div id="modalOverlay" class="modal is-hidden">

--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ import {
   updateResources,
   showSummary,
   showStatsPanel,
+  showTechTree,
 } from './ui.js';
 import { drawHeatmap, recordEnemyPosition, resetHeatmap, getHotspot } from './stats.js';
 import {
@@ -36,7 +37,7 @@ import {
   tickCooldown,
 } from './buildings.js';
 import { applyWaveRewards } from './economy.js';
-import { squads, updateSquads } from './troops.js';
+import { squads, updateSquads, spawnSquad } from './troops.js';
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
@@ -50,7 +51,11 @@ window.addEventListener('resize', resizeCanvas);
 resizeCanvas();
 
 let scale = 1;
+let offsetX = 0;
+let offsetY = 0;
 let pointers = [];
+let isPanning = false;
+let lastPan = null;
 
 function updatePinch(e) {
   for (let i = 0; i < pointers.length; i++) {
@@ -64,32 +69,71 @@ function updatePinch(e) {
     const dx = p2.clientX - p1.clientX;
     const dy = p2.clientY - p1.clientY;
     const dist = Math.hypot(dx, dy);
+    const cx = (p1.clientX + p2.clientX) / 2;
+    const cy = (p1.clientY + p2.clientY) / 2;
+    if (pointers.lastCenter) {
+      const dxC = cx - pointers.lastCenter.x;
+      const dyC = cy - pointers.lastCenter.y;
+      offsetX -= dxC / (TILE_SIZE * scale);
+      offsetY -= dyC / (TILE_SIZE * scale);
+    }
     if (pointers.lastDist) {
       let s = scale * (dist / pointers.lastDist);
-      s = Math.max(0.5, Math.min(1.5, s));
+      s = Math.max(0.5, Math.min(2, s));
       scale = s;
     }
     pointers.lastDist = dist;
+    pointers.lastCenter = { x: cx, y: cy };
   }
 }
 
 canvas.addEventListener('pointerdown', (e) => {
+  if (e.pointerType === 'mouse' && e.button === 1) {
+    isPanning = true;
+    lastPan = { x: e.clientX, y: e.clientY };
+    return;
+  }
   pointers.push(e);
 });
 canvas.addEventListener('pointermove', (e) => {
+  if (isPanning) {
+    const dx = e.clientX - lastPan.x;
+    const dy = e.clientY - lastPan.y;
+    offsetX -= dx / (TILE_SIZE * scale);
+    offsetY -= dy / (TILE_SIZE * scale);
+    lastPan = { x: e.clientX, y: e.clientY };
+    return;
+  }
   updatePinch(e);
 });
 canvas.addEventListener('pointerup', (e) => {
+  if (isPanning && e.pointerType === 'mouse' && e.button === 1) {
+    isPanning = false;
+    return;
+  }
   pointers = pointers.filter((p) => p.pointerId !== e.pointerId);
-  if (pointers.length < 2) delete pointers.lastDist;
+  if (pointers.length < 2) {
+    delete pointers.lastDist;
+    delete pointers.lastCenter;
+  }
 });
 canvas.addEventListener('pointercancel', (e) => {
   pointers = pointers.filter((p) => p.pointerId !== e.pointerId);
-  if (pointers.length < 2) delete pointers.lastDist;
+  if (pointers.length < 2) {
+    delete pointers.lastDist;
+    delete pointers.lastCenter;
+  }
 });
 
+canvas.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const delta = Math.sign(e.deltaY);
+  scale -= delta * 0.1;
+  scale = Math.max(0.5, Math.min(2, scale));
+}, { passive: false });
+
 const TILE_SIZE = TILE;
-const castle = { x: 32, y: 32, hp: 100 };
+const castle = { x: 32, y: 32, hp: 100, range: 6, rate: 48, cooldown: 0, damage: 10 };
 
 const resources = { stone: 100, wood: 150, gold: 200, essence: 0 };
 
@@ -148,6 +192,7 @@ function gameLoop() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.save();
     ctx.scale(scale, scale);
+    ctx.translate(-offsetX * TILE_SIZE, -offsetY * TILE_SIZE);
     drawGrid(ctx);
     drawBuildZone(ctx);
     drawTerrain(ctx);
@@ -173,10 +218,19 @@ function gameLoop() {
                 if (dist <= t.range && t.cooldown <= 0) {
                     const normx = dx / dist;
                     const normy = dy / dist;
-                    bullets.push({ x: t.x + 0.5, y: t.y + 0.5, dx: normx, dy: normy, speed: 1, target: e });
+                    bullets.push({ x: t.x + 0.5, y: t.y + 0.5, dx: normx, dy: normy, speed: 1, target: e, dmg: 5 });
                     t.cooldown = t.rate;
                 }
             });
+            const cdx = e.x - castle.x;
+            const cdy = e.y - castle.y;
+            const cdist = Math.hypot(cdx, cdy);
+            if (cdist <= castle.range && castle.cooldown <= 0) {
+                const nx = cdx / cdist;
+                const ny = cdy / cdist;
+                bullets.push({ x: castle.x + 0.5, y: castle.y + 0.5, dx: nx, dy: ny, speed: 1, target: e, dmg: castle.damage });
+                castle.cooldown = castle.rate;
+            }
         });
 
         bullets.forEach(b => {
@@ -192,7 +246,7 @@ function gameLoop() {
             }
             const dist = Math.hypot(b.x - e.x, b.y - e.y);
             if (dist < 0.4) {
-                e.takeDamage(5);
+                e.takeDamage(b.dmg || 5);
                 if (!e.alive) {
                     killsThisWave++;
                     if (e.type === 'elite') essenceGainThisWave += 1;
@@ -202,6 +256,7 @@ function gameLoop() {
         });
 
         towers.forEach(t => { if (t.cooldown > 0) t.cooldown -= 1; });
+        if (castle.cooldown > 0) castle.cooldown -= 1;
 
         ai.draw(ctx, TILE_SIZE);
         if (running && ai.enemies.length === 0) {
@@ -244,8 +299,8 @@ function toggleDeleteMode() {
 canvas.addEventListener('click', (e) => {
     if (running) return;
     const rect = canvas.getBoundingClientRect();
-    const x = Math.floor((e.clientX - rect.left) / TILE_SIZE);
-    const y = Math.floor((e.clientY - rect.top) / TILE_SIZE);
+    const x = Math.floor((e.clientX - rect.left) / (TILE_SIZE * scale) + offsetX);
+    const y = Math.floor((e.clientY - rect.top) / (TILE_SIZE * scale) + offsetY);
     if (deleteMode) {
         if (removeBuilding(x, y, resources)) {
             updateResources(resources.stone, resources.wood, resources.gold, resources.essence);
@@ -293,6 +348,10 @@ function closeGates() {
     closeAllGates();
 }
 
+function spawnSquadHandler() {
+    spawnSquad('infantry', castle.x + 1, castle.y + 1);
+}
+
 function endWave() {
     running = false;
     const state = {
@@ -322,6 +381,8 @@ setupUI(startWave,
     () => setBuildMode('tower'),
     toggleDeleteMode,
     openGates,
-closeGates);
+    closeGates,
+    spawnSquadHandler,
+    showTechTree);
 updateResources(resources.stone, resources.wood, resources.gold, resources.essence);
 requestAnimationFrame(gameLoop);

--- a/mobile.css
+++ b/mobile.css
@@ -60,6 +60,18 @@
   font-size: 20px;
 }
 
+.start-fab {
+  background: #a00;
+  bottom: 16px;
+  color: #fff;
+  width: 56px;
+  height: 56px;
+}
+
+.group {
+  margin-top: 4px;
+}
+
 .sheet {
   position: fixed;
   bottom: 0;

--- a/ui.js
+++ b/ui.js
@@ -6,9 +6,14 @@ export function setupUI(
   onDelete,
   onOpenGate,
   onCloseGate,
+  onSpawnSquad,
+  onShowTech,
 ) {
     const btn = document.getElementById('startBtn');
     btn.addEventListener('click', onStartWave);
+
+    const spawnBtn = document.getElementById('spawnSquadBtn');
+    if (spawnBtn) spawnBtn.addEventListener('click', onSpawnSquad);
 
     const buildBtn = document.getElementById('buildWallBtn');
     buildBtn.addEventListener('click', onBuildWall);
@@ -24,6 +29,8 @@ export function setupUI(
 
     document.getElementById('openGateBtn').addEventListener('click', onOpenGate);
     document.getElementById('closeGateBtn').addEventListener('click', onCloseGate);
+    const techBtn = document.getElementById('techBtn');
+    if (techBtn) techBtn.addEventListener('click', onShowTech);
 
     const sheetToggle = document.getElementById('sheetToggle');
     sheetToggle.addEventListener('click', () => {
@@ -41,10 +48,12 @@ export function setupUI(
         menu.classList.toggle('is-shown');
     });
 
-    const analyticsBtn = document.getElementById('analyticsBtn');
-    analyticsBtn.addEventListener('click', () => {
-        showStatsPanel('<p>Heatmap</p>');
-    });
+  const analyticsBtn = document.getElementById('analyticsBtn');
+  analyticsBtn.addEventListener('click', () => {
+      showStatsPanel('<p>Heatmap</p>');
+  });
+
+  openSheet();
 }
 
 export function showModal(id) {
@@ -106,4 +115,10 @@ export function showStatsPanel(html, onContinue) {
   btn.addEventListener('click', handler);
   close.addEventListener('click', handler);
   showModal('modalOverlay');
+}
+
+export function showTechTree() {
+  const html = `<h3>Tech Tree</h3>
+  <p>This is a placeholder technology tree. Unlock tech to build new units.</p>`;
+  showStatsPanel(html);
 }


### PR DESCRIPTION
## Summary
- restructure build panel into groups and open by default
- add floating red start-wave button
- support touch zoom/pan and mouse drag/wheel
- allow castle to fire at enemies and enemies damage over time
- add tech tree placeholder modal and squad spawn button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872813deee8833288d0b922ae59637c