### PR TITLE
Fix UI positions and improve styling

### DIFF
--- a/base.css
+++ b/base.css
@@ -94,3 +94,17 @@ button {
 .modal.is-shown {
     display: flex;
 }
+
+.tech-tree {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.tech-node {
+    background: #333;
+    border: 1px solid #666;
+    padding: 6px;
+    text-align: center;
+}

--- a/index.html
+++ b/index.html
@@ -23,9 +23,11 @@
     <main id="gameArea">
         <canvas id="gameCanvas" width="640" height="640" tabindex="0"></canvas>
         <button id="analyticsBtn" class="fab" aria-label="Analytics">&#128202;</button>
+        <button id="openGateBtn" class="fab gate-fab" aria-label="Open Gates">Open</button>
+        <button id="closeGateBtn" class="fab gate-fab" aria-label="Close Gates">Close</button>
         <button id="startBtn" class="fab start-fab" aria-label="Start Wave">Start</button>
     </main>
-    <div id="bottomSheet" class="sheet is-open">
+    <div id="bottomSheet" class="sheet">
         <button class="sheet-handle" id="sheetToggle">^</button>
         <div class="icon-row group">
             <button id="buildWallBtn" aria-label="Build Wall">&#128679;</button>
@@ -41,8 +43,6 @@
             <button id="deleteBtn" aria-label="Delete">&#9881;&#65039;</button>
         </div>
         <div class="group">
-            <button id="openGateBtn" aria-label="Open Gates">Open</button>
-            <button id="closeGateBtn" aria-label="Close Gates">Close</button>
             <button id="techBtn" aria-label="Tech Tree">Tech</button>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -133,6 +133,14 @@ canvas.addEventListener('wheel', (e) => {
 }, { passive: false });
 
 const TILE_SIZE = TILE;
+const COLORS = {
+  castle: '#4466ff',
+  wall: '#999',
+  gateClosed: '#663300',
+  gateOpen: '#00aa00',
+  tower: '#cc00cc',
+  bullet: '#ffff00'
+};
 const castle = { x: 32, y: 32, hp: 100, range: 6, rate: 48, cooldown: 0, damage: 10 };
 
 const resources = { stone: 100, wood: 150, gold: 200, essence: 0 };
@@ -156,12 +164,12 @@ let running = false;
 let killsThisWave = 0;
 
 function drawCastle() {
-    ctx.fillStyle = 'blue';
+    ctx.fillStyle = COLORS.castle;
     ctx.fillRect(castle.x * TILE_SIZE, castle.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
 }
 
 function drawWalls() {
-    ctx.fillStyle = 'gray';
+    ctx.fillStyle = COLORS.wall;
     walls.forEach(w => {
         ctx.fillRect(w.x * TILE_SIZE, w.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
     });
@@ -169,20 +177,20 @@ function drawWalls() {
 
 function drawGates() {
     gates.forEach(g => {
-        ctx.fillStyle = g.open ? 'lightgreen' : 'brown';
+        ctx.fillStyle = g.open ? COLORS.gateOpen : COLORS.gateClosed;
         ctx.fillRect(g.x * TILE_SIZE, g.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
     });
 }
 
 function drawTowers() {
-    ctx.fillStyle = 'purple';
+    ctx.fillStyle = COLORS.tower;
     towers.forEach(t => {
         ctx.fillRect(t.x * TILE_SIZE, t.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
     });
 }
 
 function drawBullets() {
-    ctx.fillStyle = 'yellow';
+    ctx.fillStyle = COLORS.bullet;
     bullets.forEach(b => {
         ctx.fillRect(b.x * TILE_SIZE, b.y * TILE_SIZE, 2, 2);
     });
@@ -325,6 +333,7 @@ canvas.addEventListener('click', (e) => {
 });
 
 function startWave() {
+    if (running) return;
     buildMode = null;
     wave += 1;
     updateWave(wave);

--- a/mobile.css
+++ b/mobile.css
@@ -53,11 +53,13 @@
 .fab {
   position: absolute;
   right: 16px;
-  bottom: 88px;
   width: 44px;
   height: 44px;
   border-radius: 50%;
   font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .start-fab {
@@ -66,6 +68,22 @@
   color: #fff;
   width: 56px;
   height: 56px;
+}
+
+#openGateBtn {
+  bottom: 88px;
+  background: #0a0;
+  color: #fff;
+}
+
+#closeGateBtn {
+  bottom: 132px;
+  background: #a52a2a;
+  color: #fff;
+}
+
+#analyticsBtn {
+  bottom: 176px;
 }
 
 .group {
@@ -101,8 +119,3 @@
   color: #fff;
 }
 
-@media (min-width: 768px) {
-  #bottomSheet {
-    display: none;
-  }
-}

--- a/ui.js
+++ b/ui.js
@@ -53,7 +53,6 @@ export function setupUI(
       showStatsPanel('<p>Heatmap</p>');
   });
 
-  openSheet();
 }
 
 export function showModal(id) {
@@ -118,7 +117,13 @@ export function showStatsPanel(html, onContinue) {
 }
 
 export function showTechTree() {
-  const html = `<h3>Tech Tree</h3>
-  <p>This is a placeholder technology tree. Unlock tech to build new units.</p>`;
+  const html = `
+    <h3>Tech Tree</h3>
+    <div class="tech-tree">
+      <div class="tech-node">Walls</div>
+      <div class="tech-node">Gates</div>
+      <div class="tech-node">Towers</div>
+    </div>
+  `;
   showStatsPanel(html);
 }


### PR DESCRIPTION
## Summary
- show build menu on desktop and keep it collapsed by default
- add gate control buttons next to the start button
- center floating action button icons and tweak positions
- add simple tech tree layout
- colourize castle, walls, gates, towers and bullets
- prevent starting a wave while another runs

## Testing
- `npx eslint .`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687283e6a5a08332919435c0848b5775