### PR TITLE
Add grouped build menu and enemy updates

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -1,11 +1,13 @@
 class Enemy {
-    constructor(x, y, type = 'normal') {
+    constructor(x, y, type = 'normal', size = 1) {
         this.x = x;
         this.y = y;
         this.type = type;
-        this.speed = type === 'elite' ? 0.4 : 0.5; // tiles per tick
+        this.size = size;
+        this.speed = type === 'elite' ? 0.25 : 0.3; // tiles per tick (slower)
         this.alive = true;
-        this.hp = type === 'elite' ? 30 : 10;
+        this.maxHp = type === 'elite' ? 30 : 10;
+        this.hp = this.maxHp;
         this.score = 0;
         this.attackCooldown = 0;
         this.atCastle = false;
@@ -55,8 +57,22 @@ class Enemy {
     }
 
     draw(ctx, tileSize) {
+        const sizePx = tileSize * this.size;
+        const cx = this.x * tileSize + sizePx / 2;
+        const cy = this.y * tileSize + sizePx / 2;
         ctx.fillStyle = this.type === 'elite' ? 'orange' : 'red';
-        ctx.fillRect(this.x * tileSize, this.y * tileSize, tileSize, tileSize);
+        ctx.beginPath();
+        ctx.arc(cx, cy, sizePx / 2, 0, Math.PI * 2);
+        ctx.fill();
+
+        // inner health bar
+        const barWidth = sizePx * 0.8;
+        const barHeight = 2;
+        const hpRatio = this.hp / this.maxHp;
+        ctx.fillStyle = 'black';
+        ctx.fillRect(cx - barWidth / 2, cy - barHeight / 2, barWidth, barHeight);
+        ctx.fillStyle = 'lime';
+        ctx.fillRect(cx - barWidth / 2, cy - barHeight / 2, barWidth * hpRatio, barHeight);
     }
 }
 
@@ -129,7 +145,12 @@ export class AIController {
             x = 63;
             y = Math.random() * 64;
         }
-        this.enemies.push(new Enemy(x, y, type));
+        // spawn four smaller enemies in a small cluster
+        for (let i = 0; i < 4; i++) {
+            const ox = (Math.random() - 0.5) * 0.5;
+            const oy = (Math.random() - 0.5) * 0.5;
+            this.enemies.push(new Enemy(x + ox, y + oy, type, 0.5));
+        }
     }
 
     update(castle, walls, gates, rocks, water) {

--- a/index.html
+++ b/index.html
@@ -29,21 +29,22 @@
     </main>
     <div id="bottomSheet" class="sheet">
         <button class="sheet-handle" id="sheetToggle">^</button>
-        <div class="icon-row group">
+        <div id="groupButtons" class="icon-row group">
+            <button id="groupWalls" aria-label="Walls">&#128719;</button>
+            <button id="groupTowers" aria-label="Defenses">&#127993;</button>
+            <button id="groupArmy" aria-label="Army">&#9876;</button>
+            <button id="deleteBtn" aria-label="Delete">&#9881;&#65039;</button>
+            <button id="techBtn" aria-label="Tech Tree">Tech</button>
+        </div>
+        <div id="submenuWalls" class="icon-row group submenu is-hidden">
             <button id="buildWallBtn" aria-label="Build Wall">&#128679;</button>
             <button id="buildGateBtn" aria-label="Build Gate">&#128682;</button>
         </div>
-        <div class="icon-row group">
+        <div id="submenuTowers" class="icon-row group submenu is-hidden">
             <button id="buildTowerBtn" aria-label="Build Tower">&#127993;</button>
         </div>
-        <div class="icon-row group">
+        <div id="submenuArmy" class="icon-row group submenu is-hidden">
             <button id="spawnSquadBtn" aria-label="Spawn Squad">&#9876;</button>
-        </div>
-        <div class="icon-row group">
-            <button id="deleteBtn" aria-label="Delete">&#9881;&#65039;</button>
-        </div>
-        <div class="group">
-            <button id="techBtn" aria-label="Tech Tree">Tech</button>
         </div>
     </div>
     <div id="modalOverlay" class="modal is-hidden">

--- a/main.js
+++ b/main.js
@@ -220,8 +220,8 @@ function gameLoop() {
             recordEnemyPosition(e.x, e.y);
             // tower attacks
             towers.forEach(t => {
-                const dx = e.x - t.x;
-                const dy = e.y - t.y;
+                const dx = (e.x + e.size / 2) - (t.x + 0.5);
+                const dy = (e.y + e.size / 2) - (t.y + 0.5);
                 const dist = Math.hypot(dx, dy);
                 if (dist <= t.range && t.cooldown <= 0) {
                     const normx = dx / dist;
@@ -230,8 +230,8 @@ function gameLoop() {
                     t.cooldown = t.rate;
                 }
             });
-            const cdx = e.x - castle.x;
-            const cdy = e.y - castle.y;
+            const cdx = (e.x + e.size / 2) - (castle.x + 0.5);
+            const cdy = (e.y + e.size / 2) - (castle.y + 0.5);
             const cdist = Math.hypot(cdx, cdy);
             if (cdist <= castle.range && castle.cooldown <= 0) {
                 const nx = cdx / cdist;
@@ -252,8 +252,8 @@ function gameLoop() {
                 bullets.splice(idx,1);
                 return;
             }
-            const dist = Math.hypot(b.x - e.x, b.y - e.y);
-            if (dist < 0.4) {
+            const dist = Math.hypot(b.x - (e.x + e.size / 2), b.y - (e.y + e.size / 2));
+            if (dist < e.size / 2 + 0.1) {
                 e.takeDamage(b.dmg || 5);
                 if (!e.alive) {
                     killsThisWave++;

--- a/map.js
+++ b/map.js
@@ -13,20 +13,30 @@ export function generateMap() {
     rocks = [];
     trees = [];
     hills = [];
-    for (let i = 0; i < 40; i++) {
-        const cell = randomCell();
-        if (!inBuildZone(cell.x, cell.y)) rocks.push(cell);
+    generateClusters(5, 8, rocks);
+    generateClusters(5, 10, trees);
+    generateClusters(3, 5, hills);
+    const hy = Math.floor(Math.random() * MAP_SIZE);
+    for (let x = 0; x < MAP_SIZE; x++) {
+        water.push({ x, y: hy });
     }
-    for (let i = 0; i < 30; i++) {
-        const cell = randomCell();
-        if (!inBuildZone(cell.x, cell.y)) trees.push(cell);
+    const vx = Math.floor(Math.random() * MAP_SIZE);
+    for (let y = 0; y < MAP_SIZE; y++) {
+        water.push({ x: vx, y });
     }
-    for (let i = 0; i < 15; i++) {
-        const cell = randomCell();
-        hills.push(cell);
+}
+
+function generateClusters(num, size, dest) {
+    for (let i = 0; i < num; i++) {
+        const center = randomCell();
+        for (let j = 0; j < size; j++) {
+            const cell = {
+                x: Math.min(Math.max(center.x + Math.floor(Math.random() * 3) - 1, 0), MAP_SIZE - 1),
+                y: Math.min(Math.max(center.y + Math.floor(Math.random() * 3) - 1, 0), MAP_SIZE - 1),
+            };
+            if (!inBuildZone(cell.x, cell.y)) dest.push(cell);
+        }
     }
-    const hy=Math.floor(Math.random()*MAP_SIZE);for(let x=0;x<MAP_SIZE;x++){water.push({x,y:hy});}
-    const vx=Math.floor(Math.random()*MAP_SIZE);for(let y=0;y<MAP_SIZE;y++){water.push({x:vx,y});}
 }
 
 function randomCell() {

--- a/mobile.css
+++ b/mobile.css
@@ -113,6 +113,14 @@
   width: 100%;
 }
 
+.submenu {
+  display: none;
+}
+
+.submenu.is-shown {
+  display: flex;
+}
+
 .sheet-handle {
   background: none;
   border: none;

--- a/ui.js
+++ b/ui.js
@@ -32,15 +32,28 @@ export function setupUI(
     const techBtn = document.getElementById('techBtn');
     if (techBtn) techBtn.addEventListener('click', onShowTech);
 
-    const sheetToggle = document.getElementById('sheetToggle');
-    sheetToggle.addEventListener('click', () => {
-        const sheet = document.getElementById('bottomSheet');
-        if (sheet.classList.contains('is-open')) {
-            closeSheet();
-        } else {
-            openSheet();
-        }
-    });
+  const sheetToggle = document.getElementById('sheetToggle');
+  sheetToggle.addEventListener('click', () => {
+      const sheet = document.getElementById('bottomSheet');
+      if (sheet.classList.contains('is-open')) {
+          closeSheet();
+      } else {
+          openSheet();
+      }
+  });
+
+  const toggle = (id) => {
+      document.querySelectorAll('.submenu').forEach(el => el.classList.remove('is-shown'));
+      const el = document.getElementById(id);
+      if (el) el.classList.add('is-shown');
+  };
+
+  const groupWalls = document.getElementById('groupWalls');
+  const groupTowers = document.getElementById('groupTowers');
+  const groupArmy = document.getElementById('groupArmy');
+  groupWalls?.addEventListener('click', () => toggle('submenuWalls'));
+  groupTowers?.addEventListener('click', () => toggle('submenuTowers'));
+  groupArmy?.addEventListener('click', () => toggle('submenuArmy'));
 
     const menuBtn = document.getElementById('menuBtn');
     menuBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- overhaul enemy class: slower speed, health bar display, spawn in clusters
- adjust bullet targeting to use enemy center
- reorganize build UI into expandable groups
- generate terrain in clusters for a more natural look

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872961ccc108332b20c6c6f9af7612a