### PR TITLE
Improve map generation and UI layout

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -4,7 +4,8 @@ class Enemy {
         this.y = y;
         this.type = type;
         this.size = size;
-        this.speed = type === 'elite' ? 0.25 : 0.3; // tiles per tick (slower)
+        // enemies move fairly quickly by default; slow them down
+        this.speed = type === 'elite' ? 0.125 : 0.15; // tiles per tick
         this.alive = true;
         this.maxHp = type === 'elite' ? 30 : 10;
         this.hp = this.maxHp;

--- a/base.css
+++ b/base.css
@@ -108,3 +108,24 @@ button {
     padding: 6px;
     text-align: center;
 }
+
+/* build controls for desktop */
+.build-buttons {
+    position: fixed;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 8px;
+}
+
+.fab-small {
+    background: #444;
+    color: #fff;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/index.html
+++ b/index.html
@@ -22,31 +22,19 @@
     <aside id="sideMenu" class="panel is-hidden"></aside>
     <main id="gameArea">
         <canvas id="gameCanvas" width="640" height="640" tabindex="0"></canvas>
+        <div id="buildControls" class="build-buttons">
+            <button id="buildWallBtn" class="fab-small" aria-label="Build Wall">&#128679;</button>
+            <button id="buildGateBtn" class="fab-small" aria-label="Build Gate">&#128682;</button>
+            <button id="buildTowerBtn" class="fab-small" aria-label="Build Tower">&#127993;</button>
+            <button id="deleteBtn" class="fab-small" aria-label="Delete">&#9881;&#65039;</button>
+            <button id="spawnSquadBtn" class="fab-small" aria-label="Spawn Squad">&#9876;</button>
+            <button id="techBtn" class="fab-small" aria-label="Tech Tree">Tech</button>
+        </div>
         <button id="analyticsBtn" class="fab" aria-label="Analytics">&#128202;</button>
         <button id="openGateBtn" class="fab gate-fab" aria-label="Open Gates">Open</button>
         <button id="closeGateBtn" class="fab gate-fab" aria-label="Close Gates">Close</button>
         <button id="startBtn" class="fab start-fab" aria-label="Start Wave">Start</button>
     </main>
-    <div id="bottomSheet" class="sheet">
-        <button class="sheet-handle" id="sheetToggle">^</button>
-        <div id="groupButtons" class="icon-row group">
-            <button id="groupWalls" aria-label="Walls">&#128719;</button>
-            <button id="groupTowers" aria-label="Defenses">&#127993;</button>
-            <button id="groupArmy" aria-label="Army">&#9876;</button>
-            <button id="deleteBtn" aria-label="Delete">&#9881;&#65039;</button>
-            <button id="techBtn" aria-label="Tech Tree">Tech</button>
-        </div>
-        <div id="submenuWalls" class="icon-row group submenu is-hidden">
-            <button id="buildWallBtn" aria-label="Build Wall">&#128679;</button>
-            <button id="buildGateBtn" aria-label="Build Gate">&#128682;</button>
-        </div>
-        <div id="submenuTowers" class="icon-row group submenu is-hidden">
-            <button id="buildTowerBtn" aria-label="Build Tower">&#127993;</button>
-        </div>
-        <div id="submenuArmy" class="icon-row group submenu is-hidden">
-            <button id="spawnSquadBtn" aria-label="Spawn Squad">&#9876;</button>
-        </div>
-    </div>
     <div id="modalOverlay" class="modal is-hidden">
         <div id="statsContent"></div>
         <button class="btn-continue" id="statsContinue">Continue</button>

--- a/main.js
+++ b/main.js
@@ -127,9 +127,17 @@ canvas.addEventListener('pointercancel', (e) => {
 
 canvas.addEventListener('wheel', (e) => {
   e.preventDefault();
+  const rect = canvas.getBoundingClientRect();
+  const cx = rect.width / 2;
+  const cy = rect.height / 2;
+  const worldX = cx / (TILE_SIZE * scale) + offsetX;
+  const worldY = cy / (TILE_SIZE * scale) + offsetY;
   const delta = Math.sign(e.deltaY);
-  scale -= delta * 0.1;
-  scale = Math.max(0.5, Math.min(2, scale));
+  let s = scale - delta * 0.1;
+  s = Math.max(0.5, Math.min(2, s));
+  offsetX = worldX - cx / (TILE_SIZE * s);
+  offsetY = worldY - cy / (TILE_SIZE * s);
+  scale = s;
 }, { passive: false });
 
 const TILE_SIZE = TILE;

--- a/map.js
+++ b/map.js
@@ -13,37 +13,40 @@ export function generateMap() {
     rocks = [];
     trees = [];
     hills = [];
-    generateClusters(5, 8, rocks);
-    generateClusters(5, 10, trees);
-    generateClusters(3, 5, hills);
-    const hy = Math.floor(Math.random() * MAP_SIZE);
-    for (let x = 0; x < MAP_SIZE; x++) {
-        water.push({ x, y: hy });
-    }
-    const vx = Math.floor(Math.random() * MAP_SIZE);
-    for (let y = 0; y < MAP_SIZE; y++) {
-        water.push({ x: vx, y });
-    }
-}
 
-function generateClusters(num, size, dest) {
-    for (let i = 0; i < num; i++) {
-        const center = randomCell();
-        for (let j = 0; j < size; j++) {
-            const cell = {
-                x: Math.min(Math.max(center.x + Math.floor(Math.random() * 3) - 1, 0), MAP_SIZE - 1),
-                y: Math.min(Math.max(center.y + Math.floor(Math.random() * 3) - 1, 0), MAP_SIZE - 1),
-            };
-            if (!inBuildZone(cell.x, cell.y)) dest.push(cell);
+    const base = Array.from({ length: MAP_SIZE }, () =>
+        Array.from({ length: MAP_SIZE }, () => Math.random())
+    );
+
+    for (let y = 1; y < MAP_SIZE - 1; y++) {
+        for (let x = 1; x < MAP_SIZE - 1; x++) {
+            let sum = 0;
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    sum += base[y + dy][x + dx];
+                }
+            }
+            base[y][x] = sum / 9;
+        }
+    }
+
+    for (let y = 0; y < MAP_SIZE; y++) {
+        for (let x = 0; x < MAP_SIZE; x++) {
+            if (inBuildZone(x, y)) continue;
+            const v = base[y][x];
+            if (v < 0.2) {
+                water.push({ x, y });
+            } else if (v < 0.35) {
+                rocks.push({ x, y });
+            } else if (v < 0.6) {
+                trees.push({ x, y });
+            } else if (v < 0.75) {
+                hills.push({ x, y });
+            }
         }
     }
 }
 
-function randomCell() {
-    const x = Math.floor(Math.random() * MAP_SIZE);
-    const y = Math.floor(Math.random() * MAP_SIZE);
-    return { x, y };
-}
 
 export function drawGrid(ctx) {
     ctx.strokeStyle = '#333';

--- a/mobile.css
+++ b/mobile.css
@@ -127,3 +127,24 @@
   color: #fff;
 }
 
+/* floating build controls */
+.build-buttons {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+}
+
+.fab-small {
+  background: #444;
+  color: #fff;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+

--- a/ui.js
+++ b/ui.js
@@ -33,27 +33,29 @@ export function setupUI(
     if (techBtn) techBtn.addEventListener('click', onShowTech);
 
   const sheetToggle = document.getElementById('sheetToggle');
-  sheetToggle.addEventListener('click', () => {
-      const sheet = document.getElementById('bottomSheet');
-      if (sheet.classList.contains('is-open')) {
-          closeSheet();
-      } else {
-          openSheet();
-      }
-  });
+  if (sheetToggle) {
+      sheetToggle.addEventListener('click', () => {
+          const sheet = document.getElementById('bottomSheet');
+          if (sheet?.classList.contains('is-open')) {
+              closeSheet();
+          } else {
+              openSheet();
+          }
+      });
 
-  const toggle = (id) => {
-      document.querySelectorAll('.submenu').forEach(el => el.classList.remove('is-shown'));
-      const el = document.getElementById(id);
-      if (el) el.classList.add('is-shown');
-  };
+      const toggle = (id) => {
+          document.querySelectorAll('.submenu').forEach(el => el.classList.remove('is-shown'));
+          const el = document.getElementById(id);
+          if (el) el.classList.add('is-shown');
+      };
 
-  const groupWalls = document.getElementById('groupWalls');
-  const groupTowers = document.getElementById('groupTowers');
-  const groupArmy = document.getElementById('groupArmy');
-  groupWalls?.addEventListener('click', () => toggle('submenuWalls'));
-  groupTowers?.addEventListener('click', () => toggle('submenuTowers'));
-  groupArmy?.addEventListener('click', () => toggle('submenuArmy'));
+      const groupWalls = document.getElementById('groupWalls');
+      const groupTowers = document.getElementById('groupTowers');
+      const groupArmy = document.getElementById('groupArmy');
+      groupWalls?.addEventListener('click', () => toggle('submenuWalls'));
+      groupTowers?.addEventListener('click', () => toggle('submenuTowers'));
+      groupArmy?.addEventListener('click', () => toggle('submenuArmy'));
+  }
 
     const menuBtn = document.getElementById('menuBtn');
     menuBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- slow down enemy movement
- center zoom on wheel scroll
- generate map using a simple smoothing algorithm for more organic terrain
- redesign build controls as floating buttons
- adjust CSS for new build button style
- guard optional UI elements in setup

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874f20f0e988332af63c8eb70880819