### PR TITLE
Add hex map and improve enemy behavior

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -4,8 +4,8 @@ class Enemy {
         this.y = y;
         this.type = type;
         this.size = size;
-        // base movement speed
-        this.baseSpeed = type === 'elite' ? 0.125 : 0.15;
+        // base movement speed (slower for realism)
+        this.baseSpeed = type === 'elite' ? 0.04 : 0.05;
         this.speed = this.baseSpeed; // current speed
         this.slowTimer = 0;
         this.alive = true;
@@ -111,7 +111,7 @@ function findNextStep(sx, sy, castle, walls, gates, rocks) {
             found = true;
             break;
         }
-        const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
+        const dirs = [[1,0],[-1,0],[0,1],[0,-1],[1,1],[-1,-1],[1,-1],[-1,1]];
         for (const [dx, dy] of dirs) {
             const nx = cx + dx;
             const ny = cy + dy;
@@ -138,28 +138,23 @@ export class AIController {
     }
 
     spawnEnemy(type = 'normal') {
-        // spawn at random edge
+        // spawn a single enemy at a random edge position
         const edge = Math.floor(Math.random() * 4);
         let x, y;
-        if (edge === 0) { // top
+        if (edge === 0) {
             x = Math.random() * 64;
             y = 0;
-        } else if (edge === 1) { // bottom
+        } else if (edge === 1) {
             x = Math.random() * 64;
             y = 63;
-        } else if (edge === 2) { // left
+        } else if (edge === 2) {
             x = 0;
             y = Math.random() * 64;
-        } else { // right
+        } else {
             x = 63;
             y = Math.random() * 64;
         }
-        // spawn four smaller enemies in a small cluster
-        for (let i = 0; i < 4; i++) {
-            const ox = (Math.random() - 0.5) * 0.5;
-            const oy = (Math.random() - 0.5) * 0.5;
-            this.enemies.push(new Enemy(x + ox, y + oy, type, 0.5));
-        }
+        this.enemies.push(new Enemy(x, y, type, 0.5));
     }
 
     update(castle, walls, gates, rocks, water) {

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ import {
   removeTree,
   MAP_SIZE,
   TILE_SIZE as TILE,
+  drawHex,
 } from './map.js';
 import { AIController } from './ai.js';
 import {
@@ -195,46 +196,39 @@ let killsThisWave = 0;
 
 function drawCastle() {
   ctx.fillStyle = COLORS.castle;
-  ctx.fillRect(
-    castle.x * TILE_SIZE,
-    castle.y * TILE_SIZE,
-    TILE_SIZE,
-    TILE_SIZE,
-  );
+  drawHex(ctx, castle.x, castle.y, COLORS.castle);
 }
 
 function drawWalls() {
-  ctx.fillStyle = COLORS.wall;
   walls.forEach((w) => {
-    ctx.fillRect(w.x * TILE_SIZE, w.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+    drawHex(ctx, w.x, w.y, COLORS.wall);
   });
 }
 
 function drawGates() {
   gates.forEach((g) => {
-    ctx.fillStyle = g.open ? COLORS.gateOpen : COLORS.gateClosed;
-    ctx.fillRect(g.x * TILE_SIZE, g.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+    drawHex(ctx, g.x, g.y, g.open ? COLORS.gateOpen : COLORS.gateClosed);
   });
 }
 
 function drawTowers() {
-  ctx.fillStyle = COLORS.tower;
   towers.forEach((t) => {
-    ctx.fillRect(t.x * TILE_SIZE, t.y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+    drawHex(ctx, t.x, t.y, COLORS.tower);
   });
 }
 
 function drawTraps() {
-  ctx.fillStyle = COLORS.trap;
   traps.forEach((t) => {
-    ctx.fillRect(t.x * TILE_SIZE + TILE_SIZE / 4, t.y * TILE_SIZE + TILE_SIZE / 4, TILE_SIZE / 2, TILE_SIZE / 2);
+    drawHex(ctx, t.x, t.y, COLORS.trap);
   });
 }
 
 function drawBullets() {
-  ctx.fillStyle = COLORS.bullet;
   bullets.forEach((b) => {
-    ctx.fillRect(b.x * TILE_SIZE, b.y * TILE_SIZE, 2, 2);
+    ctx.fillStyle = COLORS.bullet;
+    ctx.beginPath();
+    ctx.arc(b.x * TILE_SIZE + TILE_SIZE / 2, b.y * TILE_SIZE + TILE_SIZE / 2, 2, 0, Math.PI * 2);
+    ctx.fill();
   });
 }
 

--- a/map.js
+++ b/map.js
@@ -32,7 +32,6 @@ export function generateMap() {
 
     for (let y = 0; y < MAP_SIZE; y++) {
         for (let x = 0; x < MAP_SIZE; x++) {
-            if (inBuildZone(x, y)) continue;
             const v = base[y][x];
             if (v < 0.2) {
                 water.push({ x, y });
@@ -48,40 +47,47 @@ export function generateMap() {
 }
 
 
+function drawHex(ctx, x, y, fillStyle) {
+    const px = x * TILE_SIZE;
+    const py = y * TILE_SIZE;
+    ctx.beginPath();
+    ctx.moveTo(px + TILE_SIZE * 0.25, py);
+    ctx.lineTo(px + TILE_SIZE * 0.75, py);
+    ctx.lineTo(px + TILE_SIZE, py + TILE_SIZE * 0.5);
+    ctx.lineTo(px + TILE_SIZE * 0.75, py + TILE_SIZE);
+    ctx.lineTo(px + TILE_SIZE * 0.25, py + TILE_SIZE);
+    ctx.lineTo(px, py + TILE_SIZE * 0.5);
+    ctx.closePath();
+    if (fillStyle) {
+        ctx.fillStyle = fillStyle;
+        ctx.fill();
+    }
+    ctx.stroke();
+}
+
 export function drawGrid(ctx) {
     ctx.strokeStyle = '#333';
-    for (let x = 0; x <= MAP_SIZE; x++) {
-        ctx.beginPath();
-        ctx.moveTo(x * TILE_SIZE, 0);
-        ctx.lineTo(x * TILE_SIZE, MAP_SIZE * TILE_SIZE);
-        ctx.stroke();
-    }
-    for (let y = 0; y <= MAP_SIZE; y++) {
-        ctx.beginPath();
-        ctx.moveTo(0, y * TILE_SIZE);
-        ctx.lineTo(MAP_SIZE * TILE_SIZE, y * TILE_SIZE);
-        ctx.stroke();
+    for (let y = 0; y < MAP_SIZE; y++) {
+        for (let x = 0; x < MAP_SIZE; x++) {
+            drawHex(ctx, x, y);
+        }
     }
 }
 
 export function drawBuildZone(ctx) {
-    const width = (buildZoneEnd - buildZoneStart) * TILE_SIZE;
-    const height = width;
-    ctx.fillStyle = 'rgba(0, 128, 0, 0.1)';
-    ctx.fillRect(buildZoneStart * TILE_SIZE, buildZoneStart * TILE_SIZE, width, height);
-    ctx.strokeStyle = 'rgba(0, 255, 0, 0.5)';
-    ctx.strokeRect(buildZoneStart * TILE_SIZE, buildZoneStart * TILE_SIZE, width, height);
+    ctx.strokeStyle = 'rgba(0,255,0,0.5)';
+    for (let y = buildZoneStart; y < buildZoneEnd; y++) {
+        for (let x = buildZoneStart; x < buildZoneEnd; x++) {
+            drawHex(ctx, x, y, 'rgba(0,128,0,0.1)');
+        }
+    }
 }
 
 export function drawTerrain(ctx) {
-    ctx.fillStyle = '#555';
-    rocks.forEach(r => ctx.fillRect(r.x * TILE_SIZE, r.y * TILE_SIZE, TILE_SIZE, TILE_SIZE));
-    ctx.fillStyle = "#03a9f4";
-    water.forEach(w => ctx.fillRect(w.x * TILE_SIZE, w.y * TILE_SIZE, TILE_SIZE, TILE_SIZE));
-    ctx.fillStyle = '#075604';
-    trees.forEach(t => ctx.fillRect(t.x * TILE_SIZE, t.y * TILE_SIZE, TILE_SIZE, TILE_SIZE));
-    ctx.fillStyle = '#444';
-    hills.forEach(h => ctx.fillRect(h.x * TILE_SIZE, h.y * TILE_SIZE, TILE_SIZE, TILE_SIZE));
+    rocks.forEach(r => drawHex(ctx, r.x, r.y, '#555'));
+    water.forEach(w => drawHex(ctx, w.x, w.y, '#03a9f4'));
+    trees.forEach(t => drawHex(ctx, t.x, t.y, '#075604'));
+    hills.forEach(h => drawHex(ctx, h.x, h.y, '#444'));
 }
 
 export function inBuildZone(x, y) {
@@ -131,3 +137,5 @@ export function expandBuildZone() {
 export function getBuildZone() {
     return { start: buildZoneStart, end: buildZoneEnd };
 }
+
+export { drawHex };


### PR DESCRIPTION
## Summary
- render all map tiles as hexagons
- generate terrain inside the build zone
- slow enemies down and allow diagonal pathfinding
- spawn enemies individually at random edges
- adapt drawing code for hex tiles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68765a97cae88332ba7c74b7c5dc5ab0