### PR TITLE
Improve hex rendering performance

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,9 @@ import {
   removeTree,
   MAP_SIZE,
   TILE_SIZE as TILE,
+  HEX_HEIGHT as HEX_H,
   drawHex,
+  refreshStatic,
 } from './map.js';
 import { AIController } from './ai.js';
 import {
@@ -85,7 +87,7 @@ function updatePinch(e) {
       const dxC = cx - pointers.lastCenter.x;
       const dyC = cy - pointers.lastCenter.y;
       offsetX -= dxC / (TILE_SIZE * 0.75 * scale);
-      offsetY -= dyC / (TILE_SIZE * scale);
+      offsetY -= dyC / (HEX_HEIGHT * scale);
     }
     if (pointers.lastDist) {
       let s = scale * (dist / pointers.lastDist);
@@ -110,7 +112,7 @@ canvas.addEventListener('pointermove', (e) => {
     const dx = e.clientX - lastPan.x;
     const dy = e.clientY - lastPan.y;
     offsetX -= dx / (TILE_SIZE * 0.75 * scale);
-    offsetY -= dy / (TILE_SIZE * scale);
+    offsetY -= dy / (HEX_HEIGHT * scale);
     lastPan = { x: e.clientX, y: e.clientY };
     return;
   }
@@ -143,18 +145,19 @@ canvas.addEventListener(
     const cx = rect.width / 2;
     const cy = rect.height / 2;
     const worldX = cx / (TILE_SIZE * 0.75 * scale) + offsetX;
-    const worldY = cy / (TILE_SIZE * scale) + offsetY;
+    const worldY = cy / (HEX_HEIGHT * scale) + offsetY;
     const delta = Math.sign(e.deltaY);
     let s = scale - delta * 0.1;
     s = Math.max(0.5, Math.min(2, s));
     offsetX = worldX - cx / (TILE_SIZE * 0.75 * s);
-    offsetY = worldY - cy / (TILE_SIZE * s);
+    offsetY = worldY - cy / (HEX_HEIGHT * s);
     scale = s;
   },
   { passive: false },
 );
 
 const TILE_SIZE = TILE;
+const HEX_HEIGHT = HEX_H;
 const COLORS = {
   castle: '#4466ff',
   wall: '#999',
@@ -228,7 +231,7 @@ function drawBullets() {
     ctx.fillStyle = COLORS.bullet;
     ctx.beginPath();
     const px = b.x * TILE_SIZE * 0.75 + TILE_SIZE / 2;
-    const py = b.y * TILE_SIZE + (Math.floor(b.x) % 2) * (TILE_SIZE / 2) + TILE_SIZE / 2;
+    const py = b.y * HEX_HEIGHT + (Math.floor(b.x) % 2) * (HEX_HEIGHT / 2) + HEX_HEIGHT / 2;
     ctx.arc(px, py, 2, 0, Math.PI * 2);
     ctx.fill();
   });
@@ -238,7 +241,7 @@ function gameLoop() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.save();
   ctx.scale(scale, scale);
-  ctx.translate(-offsetX * TILE_SIZE * 0.75, -offsetY * TILE_SIZE);
+  ctx.translate(-offsetX * TILE_SIZE * 0.75, -offsetY * HEX_HEIGHT);
   drawGrid(ctx);
   drawBuildZone(ctx);
   drawTerrain(ctx);
@@ -248,7 +251,7 @@ function gameLoop() {
   drawTraps();
   drawTowers();
   drawBullets();
-  if (!running) drawHeatmap(ctx, TILE_SIZE);
+  if (!running) drawHeatmap(ctx);
   updateSquads();
   tickCooldown();
   const killed = ai.update(castle, walls, gates, rocks, water);
@@ -398,7 +401,7 @@ function handleBuildEvent(e) {
   const scaleY = canvas.height / rect.height;
   const rawX = clientX * scaleX / (TILE_SIZE * 0.75 * scale) + offsetX;
   const x = Math.floor(rawX);
-  const rawY = clientY * scaleY / (TILE_SIZE * scale) + offsetY - (x % 2) * 0.5;
+  const rawY = clientY * scaleY / (HEX_HEIGHT * scale) + offsetY - (x % 2) * 0.5;
   const y = Math.floor(rawY);
   if (deleteMode) {
     if (removeBuilding(x, y, resources)) {

--- a/map.js
+++ b/map.js
@@ -1,5 +1,6 @@
 export const MAP_SIZE = 64; // 64x64 grid
-export const TILE_SIZE = 10; // pixels
+export const TILE_SIZE = 10; // width of a hexagon in pixels
+export const HEX_HEIGHT = TILE_SIZE * Math.sqrt(3) / 2;
 let buildZoneStart = 22; // 20x20 center area -> start index 22 to 42 for 64 grid
 let buildZoneEnd = 42;
 
@@ -8,6 +9,25 @@ let trees = [];
 let hills = [];
 
 let water = [];
+const staticCanvas = document.createElement('canvas');
+const staticCtx = staticCanvas.getContext('2d');
+
+function refreshStatic() {
+    const width = MAP_SIZE * TILE_SIZE * 0.75 + TILE_SIZE;
+    const height = MAP_SIZE * HEX_HEIGHT + HEX_HEIGHT;
+    staticCanvas.width = width;
+    staticCanvas.height = height;
+    staticCtx.clearRect(0, 0, width, height);
+    for (let y = 0; y < MAP_SIZE; y++) {
+        for (let x = 0; x < MAP_SIZE; x++) {
+            drawHex(staticCtx, x, y, '#222');
+        }
+    }
+    rocks.forEach(r => drawHex(staticCtx, r.x, r.y, '#555'));
+    water.forEach(w => drawHex(staticCtx, w.x, w.y, '#03a9f4'));
+    trees.forEach(t => drawHex(staticCtx, t.x, t.y, '#075604'));
+    hills.forEach(h => drawHex(staticCtx, h.x, h.y, '#444'));
+}
 export function generateMap() {
     water = [];
     rocks = [];
@@ -44,34 +64,30 @@ export function generateMap() {
             }
         }
     }
+
+    refreshStatic();
 }
 
 
 function drawHex(ctx, x, y, fillStyle) {
     const px = x * TILE_SIZE * 0.75;
-    const py = y * TILE_SIZE + (x % 2) * (TILE_SIZE / 2);
+    const py = y * HEX_HEIGHT + (x % 2) * (HEX_HEIGHT / 2);
     ctx.beginPath();
     ctx.moveTo(px + TILE_SIZE * 0.25, py);
     ctx.lineTo(px + TILE_SIZE * 0.75, py);
-    ctx.lineTo(px + TILE_SIZE, py + TILE_SIZE * 0.5);
-    ctx.lineTo(px + TILE_SIZE * 0.75, py + TILE_SIZE);
-    ctx.lineTo(px + TILE_SIZE * 0.25, py + TILE_SIZE);
-    ctx.lineTo(px, py + TILE_SIZE * 0.5);
+    ctx.lineTo(px + TILE_SIZE, py + HEX_HEIGHT / 2);
+    ctx.lineTo(px + TILE_SIZE * 0.75, py + HEX_HEIGHT);
+    ctx.lineTo(px + TILE_SIZE * 0.25, py + HEX_HEIGHT);
+    ctx.lineTo(px, py + HEX_HEIGHT / 2);
     ctx.closePath();
     if (fillStyle) {
         ctx.fillStyle = fillStyle;
         ctx.fill();
     }
-    ctx.stroke();
 }
 
 export function drawGrid(ctx) {
-    ctx.strokeStyle = '#333';
-    for (let y = 0; y < MAP_SIZE; y++) {
-        for (let x = 0; x < MAP_SIZE; x++) {
-            drawHex(ctx, x, y);
-        }
-    }
+    ctx.drawImage(staticCanvas, 0, 0);
 }
 
 export function drawBuildZone(ctx) {
@@ -83,11 +99,8 @@ export function drawBuildZone(ctx) {
     }
 }
 
-export function drawTerrain(ctx) {
-    rocks.forEach(r => drawHex(ctx, r.x, r.y, '#555'));
-    water.forEach(w => drawHex(ctx, w.x, w.y, '#03a9f4'));
-    trees.forEach(t => drawHex(ctx, t.x, t.y, '#075604'));
-    hills.forEach(h => drawHex(ctx, h.x, h.y, '#444'));
+export function drawTerrain() {
+    /* terrain is pre-rendered to the static canvas */
 }
 
 export function inBuildZone(x, y) {
@@ -138,4 +151,4 @@ export function getBuildZone() {
     return { start: buildZoneStart, end: buildZoneEnd };
 }
 
-export { drawHex };
+export { drawHex, refreshStatic };

--- a/stats.js
+++ b/stats.js
@@ -1,3 +1,5 @@
+import { drawHex } from './map.js';
+
 export let heatmap = Array.from({ length: 64 }, () => Array(64).fill(0));
 
 export function recordEnemyPosition(x, y) {
@@ -12,7 +14,7 @@ export function resetHeatmap() {
   heatmap = Array.from({ length: 64 }, () => Array(64).fill(0));
 }
 
-export function drawHeatmap(ctx, tileSize) {
+export function drawHeatmap(ctx) {
   const max = Math.max(...heatmap.flat());
   if (max === 0) return;
   for (let y = 0; y < 64; y++) {
@@ -20,8 +22,7 @@ export function drawHeatmap(ctx, tileSize) {
       const val = heatmap[y][x];
       if (val > 0) {
         const intensity = val / max;
-        ctx.fillStyle = `rgba(255,0,0,${intensity * 0.6})`;
-        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+        drawHex(ctx, x, y, `rgba(255,0,0,${intensity * 0.6})`);
       }
     }
   }


### PR DESCRIPTION
## Summary
- optimize map drawing by caching the grid and terrain in an offscreen canvas
- remove strokes from hex tiles and compute proper hex height
- update main logic to use the new hex geometry
- show heat map using hexes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68767357b61883328692f57221d9903a