### PR TITLE
Refactor AI and stats to use MAP_SIZE

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -1,3 +1,4 @@
+import { MAP_SIZE } from "./map.js";
 class Enemy {
     constructor(x, y, type = 'normal', size = 1) {
         this.x = x;
@@ -117,7 +118,7 @@ function findNextStep(sx, sy, castle, walls, gates, rocks) {
         for (const [dx, dy] of dirs) {
             const nx = cx + dx;
             const ny = cy + dy;
-            if (nx < 0 || ny < 0 || nx >= 64 || ny >= 64) continue;
+            if (nx < 0 || ny < 0 || nx >= MAP_SIZE || ny >= MAP_SIZE) continue;
             const key = `${nx},${ny}`;
             if (blocked.has(key) || visited.has(key)) continue;
             visited.add(key);
@@ -144,17 +145,17 @@ export class AIController {
         const edge = Math.floor(Math.random() * 4);
         let x, y;
         if (edge === 0) {
-            x = Math.random() * 64;
+            x = Math.random() * MAP_SIZE;
             y = 0;
         } else if (edge === 1) {
-            x = Math.random() * 64;
-            y = 63;
+            x = Math.random() * MAP_SIZE;
+            y = MAP_SIZE - 1;
         } else if (edge === 2) {
             x = 0;
-            y = Math.random() * 64;
+            y = Math.random() * MAP_SIZE;
         } else {
-            x = 63;
-            y = Math.random() * 64;
+            x = MAP_SIZE - 1;
+            y = Math.random() * MAP_SIZE;
         }
         this.enemies.push(new Enemy(x, y, type, 0.5));
     }

--- a/stats.js
+++ b/stats.js
@@ -1,24 +1,24 @@
-import { drawHex } from './map.js';
+import { drawHex, MAP_SIZE } from './map.js';
 
-export let heatmap = Array.from({ length: 64 }, () => Array(64).fill(0));
+export let heatmap = Array.from({ length: MAP_SIZE }, () => Array(MAP_SIZE).fill(0));
 
 export function recordEnemyPosition(x, y) {
   const cx = Math.floor(x);
   const cy = Math.floor(y);
-  if (cx >= 0 && cy >= 0 && cx < 64 && cy < 64) {
+  if (cx >= 0 && cy >= 0 && cx < MAP_SIZE && cy < MAP_SIZE) {
     heatmap[cy][cx] += 1;
   }
 }
 
 export function resetHeatmap() {
-  heatmap = Array.from({ length: 64 }, () => Array(64).fill(0));
+  heatmap = Array.from({ length: MAP_SIZE }, () => Array(MAP_SIZE).fill(0));
 }
 
 export function drawHeatmap(ctx) {
   const max = Math.max(...heatmap.flat());
   if (max === 0) return;
-  for (let y = 0; y < 64; y++) {
-    for (let x = 0; x < 64; x++) {
+  for (let y = 0; y < MAP_SIZE; y++) {
+    for (let x = 0; x < MAP_SIZE; x++) {
       const val = heatmap[y][x];
       if (val > 0) {
         const intensity = val / max;
@@ -35,8 +35,8 @@ export function getHotspot() {
   if (total === 0) return null;
   if (max / total > 0.6) {
     const idx = flat.indexOf(max);
-    const y = Math.floor(idx / 64);
-    const x = idx % 64;
+    const y = Math.floor(idx / MAP_SIZE);
+    const x = idx % MAP_SIZE;
     return { x, y };
   }
   return null;


### PR DESCRIPTION
## Summary
- import `MAP_SIZE` in AI and statistics modules
- use `MAP_SIZE` instead of numeric map boundaries

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876860382688332863f9df8b087ac54